### PR TITLE
[-] FO : Modification to save carriercompare choice to page 4

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -790,9 +790,14 @@ class CartRuleCore extends ObjectModel
 			if ($this->reduction_percent && $this->reduction_product == 0)
 			{
 				// Do not give a reduction on free products!
+				// It's written "on the whole order", but we can't include shipping 
+				// otherwise it makes an infinite recursion!!!!
 				$order_total = $context->cart->getOrderTotal($use_tax, Cart::ONLY_PRODUCTS, $package_products);
 				foreach ($context->cart->getCartRules(CartRule::FILTER_ACTION_GIFT) as $cart_rule)
-					$order_total -= Tools::ps_round($cart_rule['obj']->getContextualValue($use_tax, $context, CartRule::FILTER_ACTION_GIFT, $package), 2);
+					$order_total -= Tools::ps_round(
+							$cart_rule['obj']->getContextualValue(
+								$use_tax, $context, CartRule::FILTER_ACTION_GIFT, $package),
+							2);
 
 				$reduction_value += $order_total * $this->reduction_percent / 100;
 			}


### PR DESCRIPTION
Following this thread : http://www.prestashop.com/forums/topic/309699-impossible-de-valider-un-transporteur-dans-le-panier-carriercompare/
this is the modification I've made on several files in order to be able to validate the carrier "Paquet prioritaire" in carriercompare page 1 of the checkout.This validation ist still kept in page 4 of the checkout.
It works here. Please check that it won't create bugs somewhere else as I have little knowledge of the code and ...
NB : This part of the code that manages carrier validation, shipping cost makes repetitive calls both directions (classes cart et carrier). You have to put traces in to believe it. Dozens or even hundreds of the same calls or sequences of calls. It takes very little for the snake to bite his tail and enter infinite recursion. There's too many functionalities processed along the code that would deserve to be taken out into separate methods conditionned by parameters. As it is now, it's heavy, long, and hard to maintain.
Last but not least, repeating dozens of times the same calls impacts response times badly.

Kind regards.
PBo
