### PR TITLE
[-] BO: Fixed undefined constant

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -74,6 +74,7 @@ define('_PS_PROD_IMG_DIR_',         _PS_IMG_DIR_.'p/');
 define('_PS_SCENE_IMG_DIR_',        _PS_IMG_DIR_.'scenes/');
 define('_PS_SCENE_THUMB_IMG_DIR_',  _PS_IMG_DIR_.'scenes/thumbs/');
 define('_PS_MANU_IMG_DIR_',         _PS_IMG_DIR_.'m/');
+define('_PS_ORDER_STATE_IMG_DIR_',  _PS_IMG_DIR_.'os/');
 define('_PS_SHIP_IMG_DIR_',         _PS_IMG_DIR_.'s/');
 define('_PS_SUPP_IMG_DIR_',         _PS_IMG_DIR_.'su/');
 define('_PS_COL_IMG_DIR_',			_PS_IMG_DIR_.'co/');


### PR DESCRIPTION
This constant is used [here](https://github.com/PrestaShop/PrestaShop-1.5/blob/master/controllers/admin/AdminStatusesController.php#L548) but not defined anywhere so it causes an error.
