### PR TITLE
Update Notification.php

### DIFF
--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -50,8 +50,12 @@ class NotificationCore
 				WHERE `id_employee` = '.(int)$cookie->id_employee);
 
 		foreach ($this->types as $type)
-			$notifications[$type] = Notification::getLastElementsIdsByType($type, $employee_infos['id_last_'.$type]);
-
+		{
+			if ($employee_infos['id_last_'.$type] != '0')
+				$notifications[$type] = Notification::getLastElementsIdsByType($type, $employee_infos['id_last_'.$type]);
+			else
+				$notifications[$type] = array();
+		}
 		return $notifications;
 	}
 


### PR DESCRIPTION
Figured out that after creating a new employe, id_last_order, id_last_customer_message and id_last_customer where egal 0, asking on getLastElementsIdsByType to find every order/message/customer with id > 0... On the large shop I tested, It reached more than 300Mo memory...
