### PR TITLE
Update prices.tpl

### DIFF
--- a/admin-dev/themes/default/template/controllers/products/prices.tpl
+++ b/admin-dev/themes/default/template/controllers/products/prices.tpl
@@ -341,7 +341,7 @@ $(document).ready(function () {
 					ampm: false,
 					amNames: ['AM', 'A'],
 					pmNames: ['PM', 'P'],
-					timeFormat: 'hh:mm:ss tt',
+					timeFormat: 'hh:mm:ss',
 					timeSuffix: '',
 					timeOnlyTitle: '{l s='Choose Time'}',
 					timeText: '{l s='Time'}',


### PR DESCRIPTION
"tt" means am / pm and isn't taken into account with datetimepicker v0.9.9.
For one of my module, I use datetimepicker v1.4.5 and "tt" is taken into account, making impossible to save a specific price and giving a 'The from/to date is invalid.' error.
