### PR TITLE
[-] BO: Fixed Cart::getDeliveryOptionList()

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1938,8 +1938,7 @@ class CartCore extends ObjectModel
 				// No carriers available
 				if (count($package['carrier_list']) == 1 && current($package['carrier_list']) == 0)
 				{	
-					$cache = array();
-					return $cache;
+					continue;
 				}
 
 				$carriers_price[$id_address][$id_package] = array();


### PR DESCRIPTION
If there are multiple packages and one of them is empty this function returns an empty array. It shouldn't do that when some of the packages are not empty.
