### PR TITLE
Fixed error that showed already used cart rules

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -249,17 +249,21 @@ class CartRuleCore extends ObjectModel
 				unset($result[$key]);
 			}
 
-		foreach ($result as &$cart_rule)
-			if ($cart_rule['quantity_per_user'])
-			{
-				$quantity_used = Order::getDiscountsCustomer((int)$id_customer, (int)$cart_rule['id_cart_rule']);
-				if (isset($cart) && isset($cart->id))
-					$quantity_used += $cart->getDiscountsCustomer((int)$cart_rule['id_cart_rule']);
-				$cart_rule['quantity_for_user'] = $cart_rule['quantity_per_user'] - $quantity_used;
+		foreach ($result as $key => $cart_rule) {
+		    if ($cart_rule['quantity_per_user']) {
+			$quantity_used = Order::getDiscountsCustomer((int)$id_customer, (int)$cart_rule['id_cart_rule']);
+
+			if (isset($cart) && isset($cart->id)) {
+			    $quantity_used += $cart->getDiscountsCustomer((int)$cart_rule['id_cart_rule']);
 			}
-			else
-				$cart_rule['quantity_for_user'] = 0;
-		unset($cart_rule);
+			$cart_rule['quantity_for_user'] = $cart_rule['quantity_per_user'] - $quantity_used;
+			if(!$cart_rule['quantity_for_user']){
+			    unset($result[$key]);
+			}
+		    } else {
+			$cart_rule['quantity_for_user'] = 0;
+		    }
+		}
 		
 		foreach ($result as $cart_rule)
 			if ($cart_rule['shop_restriction'])


### PR DESCRIPTION
When available for user is 0 and available for all users is not 0 the cart rules where showing on the cart as available.